### PR TITLE
Add sample endpoints for getting jambase geographies

### DIFF
--- a/backend/src/routes/record.ts
+++ b/backend/src/routes/record.ts
@@ -15,6 +15,89 @@ const axios = require('axios');
 const API_KEY_JAMBASE = process.env.API_KEY_JAMBASE || '';
 const cachedData: { victoria_data?: any; rifflandia_data?: any } = {}; // The in-memory cache object
 
+recordRoutes.route('/geographies/countries').get(async (req, res) => {
+  console.log('Request body: ', req);
+  const sampleResponse = {
+    countries: [
+      {
+        '@type': 'Country',
+        identifier: 'US',
+        name: 'United States',
+        alternateName: 'USA',
+        'x-numUpcomingEvents': 12,
+      },
+    ],
+  };
+  res.status(200).json(sampleResponse);
+});
+
+recordRoutes.route('/geographies/states').get(async (req, res) => {
+  console.log('Request body: ', req);
+  const sampleResponse = {
+    states: [
+      {
+        '@type': 'State',
+        identifier: 'US-AZ',
+        name: 'Arizona',
+        alternateName: 'AZ',
+        country: {
+          '@type': 'Country',
+          identifier: 'US',
+          name: 'United States',
+          alternateName: 'USA',
+          'x-numUpcomingEvents': 12,
+        },
+        'x-numUpcomingEvents': 12,
+      },
+    ],
+  };
+  res.status(200).json(sampleResponse);
+});
+
+recordRoutes.route('/geographies/metros').get(async (req, res) => {
+  console.log('Request body: ', req);
+  const sampleResponse = {
+    metros: [
+      {
+        '@type': 'AdministrativeArea',
+        identifier: 'jambase:13412',
+        name: 'New York Area',
+        geo: {
+          '@type': 'GeoCoordinates',
+          latitude: 40.7505,
+          longitude: -73.9934,
+        },
+        address: {
+          addressRegion: 'US-AZ',
+          addressCountry: 'US',
+        },
+        containsPlace: [
+          {
+            '@type': 'City',
+            identifier: 'jambase:13412',
+            name: 'New York',
+            geo: {
+              '@type': 'GeoCoordinates',
+              latitude: 40.7505,
+              longitude: -73.9934,
+            },
+            address: {
+              addressRegion: 'US-AZ',
+              addressCountry: 'US',
+            },
+            'x-timezone': 'America/New_York',
+            containedInPlace: {},
+            'x-numUpcomingEvents': 12,
+          },
+        ],
+        'x-primaryCityId': 12,
+        'x-numUpcomingEvents': 12,
+      },
+    ],
+  };
+  res.status(200).json(sampleResponse);
+});
+
 recordRoutes.route('/jamBase').get(async (req, response) => {
   const { city } = req.query;
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Adds 3 GET endpoints on the backend for getting a list of either Countries, States/Provinces, or Metros.

Sample responses include the data models.

`/geographies/countries`
`/geographies/states`
`/geographies/metros`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] `curl http://localhost:5000/geographies/countries`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

