### PR TITLE
Fix playlist creation for custom-filtered gig lists

### DIFF
--- a/backend/src/controller/victoriaController.ts
+++ b/backend/src/controller/victoriaController.ts
@@ -17,19 +17,24 @@ victoriaRouter.route("/artists").get(async (req, response) => {
 });
 
 victoriaRouter.route("/create").post(async (req, response) => {
-  const { token, city, user_id, numTopTracks, sortBy } = req.body;
+  const { token, city, user_id, numTopTracks, sortBy, overrideGigs } = req.body;
 
-  const db_connect = await connectToDatabase();
-  const collection: Collection<Gig> = db_connect.collection(`${city}`);
-  const gigs: Gig[] = await collection.find({}).toArray();
+  let gigs: Gig[] = [];
+  if (overrideGigs) {
+    gigs = overrideGigs;
+  } else {
+    const db_connect = await connectToDatabase();
+    const collection: Collection<Gig> = db_connect.collection(`${city}`);
+    gigs = await collection.find({}).toArray();
+  }
 
   const url = await CreateNewPlaylist({
-    token: token,
-    city: city,
-    user_id: user_id,
-    numTopTracks: numTopTracks,
-    gigs: gigs,
-    sortBy: sortBy,
+    token,
+    city,
+    user_id,
+    numTopTracks,
+    gigs,
+    sortBy,
   }).catch((error) => {
     console.log(error);
     response.status(500).json({ error: error.message });

--- a/client/src/apiManager/RecordShop.ts
+++ b/client/src/apiManager/RecordShop.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { filterRecent, sortByPopularity, sortDataByDateAndOrder } from "../utils/sorter";
 import { Cities, Festivals } from "../constants/enums";
+import { Gig } from "../types/Gig";
 
 export const GetTickets = async ({ queryKey }: { queryKey: any }): Promise<any> => {
   // eslint-disable-next-line
@@ -30,20 +31,22 @@ export const CreateNewPlaylist = async ({
   city,
   user_id,
   numTopTracks,
+  overrideGigs,
   sortBy = "date",
 }: {
   token: string;
   city: string;
   user_id: string;
   numTopTracks?: number;
+  overrideGigs?: Gig[];
   sortBy?: "popularity" | "date";
 }) => {
-  const reqBody = {
-    token: token,
-    user_id: user_id,
-    city: city,
-    numTopTracks: numTopTracks,
-    sortBy: sortBy,
-  };
-  return await axios.post(import.meta.env.VITE_SITE_URL_DB + "create/", reqBody);
+  return await axios.post(import.meta.env.VITE_SITE_URL_DB + "create/", {
+    token,
+    user_id,
+    city,
+    numTopTracks,
+    sortBy,
+    overrideGigs,
+  });
 };

--- a/client/src/festivals/PhillipsBackyard2024/PhillipsBackyard2024.tsx
+++ b/client/src/festivals/PhillipsBackyard2024/PhillipsBackyard2024.tsx
@@ -52,6 +52,7 @@ export const PhillipsBackyard2024 = () => {
   const { isCreatingPlaylist, handleCreatePlaylist } = useCreatePlaylistState({
     dbCollectionName: DB_COLLECTION_NAME,
     numTopTracks,
+    overrideGigs: filteredGigs,
   });
 
   setDocumentTitle("Record Shop | Phillips Backyard 2024");

--- a/client/src/hooks/useCreatePlaylistState.ts
+++ b/client/src/hooks/useCreatePlaylistState.ts
@@ -3,13 +3,15 @@ import { CreateNewPlaylist } from "../apiManager/RecordShop";
 import { SnackBarContext } from "../App";
 import { goToNewTabOnDesktop } from "../utils/browserUtils";
 import { useAuth } from "../context/AuthContext";
+import { Gig } from "../types/Gig";
 
 type PlaylistStateProps = {
   dbCollectionName: string;
   numTopTracks: number;
+  overrideGigs?: Gig[];
 };
 
-export const useCreatePlaylistState = ({ dbCollectionName, numTopTracks }: PlaylistStateProps) => {
+export const useCreatePlaylistState = ({ dbCollectionName, numTopTracks, overrideGigs }: PlaylistStateProps) => {
   const { token, spotifyInfo } = useAuth();
 
   const [isCreatingPlaylist, setIsCreatingPlaylist] = useState(false);
@@ -31,9 +33,10 @@ export const useCreatePlaylistState = ({ dbCollectionName, numTopTracks }: Playl
     setIsCreatingPlaylist(true);
     await CreateNewPlaylist({
       city: dbCollectionName,
-      token: token,
+      token,
       user_id: spotifyInfo.user_id,
-      numTopTracks: numTopTracks,
+      numTopTracks,
+      overrideGigs,
     })
       .then((res) => {
         if (res.status === 201) {


### PR DESCRIPTION
#### What does this PR do? (please include some screenshots if you got em!)
Add option to override gigs in playlist creation rather than looking them up in the db.
For Phillips 2024, we pass in the filtered gigs (by weekend) which then get used in the playlist creation (this was a bug from my last PR.. oops!)

#### Where should the reviewer start reading?
The BE controller where we decide to use either the overridden gigs or look them up in the DB (`backend/src/controller/victoriaController.ts`).

#### How should these changes be tested / verified?
Select a specific weekend on the Phillips 2024 page and then create a playlist; ensure only that weekend's artists are included in the playlist.

#### How does this PR make you feel?

<!-- https://giphy.com/ is a good source for GIFs -->
<img src="https://media.giphy.com/media/XyLKdaVbQ3xg6o0sKy/giphy.gif?cid=790b76111bm7278okx8k4wa3v9olji7py0pq5mu9cgp9kv8p&ep=v1_gifs_search&rid=giphy.gif&ct=g" width="340"/>
